### PR TITLE
Fix render of popular products after login

### DIFF
--- a/Source/Tailwind.Traders.Web/ClientApp/src/pages/home/homeContainer.js
+++ b/Source/Tailwind.Traders.Web/ClientApp/src/pages/home/homeContainer.js
@@ -48,12 +48,13 @@ class HomeContainer extends Component {
 
     async shouldComponentUpdate(nextProps) {
         if ((this.props.userInfo.loggedIn !== nextProps.userInfo.loggedIn) && nextProps.userInfo.loggedIn) {
-            await this.renderPopularProducts()
+            await this.renderPopularProducts(nextProps.userInfo.token)
         }
     }
 
-    async renderPopularProducts() {
-        const token = this.props.userInfo.token;
+    async renderPopularProducts(token) {
+        token = token || this.props.userInfo.token;
+
         let popularProducts = await ProductService.getHomePageData(token);
 
         if (popularProducts && popularProducts.data.popularProducts) {


### PR DESCRIPTION
Steps to reproduce the bug before the fix
1. Go to landing page
2. Login
3. Render products was not loaded

