### PR TITLE
Add debug information

### DIFF
--- a/Source/Tailwind.Traders.Web/ClientApp/src/App.js
+++ b/Source/Tailwind.Traders.Web/ClientApp/src/App.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { CartService } from './services';
 import { ConfigService } from './services'
 
-import { Header, Footer } from "./shared";
+import { Header, Footer, DebugHeader } from "./shared";
 import { Home, List, MyCoupons, Detail, SuggestedProductsList, Profile, ShoppingCart } from "./pages";
 
 import "./i18n";
@@ -69,6 +69,7 @@ class App extends Component {
             <div className="App">
                 <Router history={history}>
                     <Fragment>
+                        <DebugHeader />
                         <Header quantity={quantity} />
                         <Route exact path="/" component={Home} />
                         <Route exact path="/list" component={List} />

--- a/Source/Tailwind.Traders.Web/ClientApp/src/services/configService.js
+++ b/Source/Tailwind.Traders.Web/ClientApp/src/services/configService.js
@@ -28,6 +28,7 @@ const ConfigService = {
     _B2cClientId: B2cClientId,
     _B2cScopes: B2cScopes,
     _applicationInsightsIntrumentationKey: '',
+    _debugInformation: {},
 
     async loadSettings() {
         if (this._needLoadSettings) {
@@ -41,6 +42,7 @@ const ConfigService = {
             this._B2cScopes = settingsResponse.data.b2CAuth.scopes;
             this._devspacesName = settingsResponse.data.devspacesName;
             this._applicationInsightsIntrumentationKey = settingsResponse.data.applicationInsights.instrumentationKey;
+            this._debugInformation = settingsResponse.data.debugInformation;
         }
     },
 

--- a/Source/Tailwind.Traders.Web/ClientApp/src/shared/debugHeader/debugHeader.js
+++ b/Source/Tailwind.Traders.Web/ClientApp/src/shared/debugHeader/debugHeader.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react';
+import { Link } from "react-router-dom";
+import { ConfigService } from "../../services";
+import { withNamespaces } from "react-i18next";
+
+import { ReactComponent as Logo } from "../../assets/images/logo-horizontal.svg";
+
+class DebugHeader extends Component {
+    constructor() {
+        super();
+        this.state = {
+            debugInfo: {}
+        };
+    }
+
+    async componentDidMount() {
+        await ConfigService.loadSettings();
+        this.setState({ debugInfo: ConfigService._debugInformation });
+    }
+
+    render() {
+        const debugInfo = this.state.debugInfo;
+        const spans = [];
+
+        if (debugInfo.customText) {
+            spans.push(<span style={{ "margin": "0px 20px" }}><strong>{debugInfo.customText}</strong></span>)
+        }
+        
+        if (debugInfo.sqlServerName) {
+            spans.push(<span style={{ "margin": "0px 20px" }}>SQL Server: <strong>{debugInfo.sqlServerName}</strong></span>)
+        }
+        if (debugInfo.mongoServerName) {
+            spans.push(<span style={{ "margin": "0px 20px" }}>Mongo Server: <strong>{debugInfo.mongoServerName}</strong></span>)
+        }
+
+        if (this.state.debugInfo.showDebug) {
+            return (
+                <debug-header style={{
+                    "display": "block", 
+                    "padding": "6px 0px", 
+                    "text-align": "center",
+                    "background-color": "rgb(227, 232, 236)"
+                }}>
+                    { spans }
+                </debug-header>
+            );
+        } else {
+            return <div></div>;
+        }
+    }
+
+}
+
+export default withNamespaces()(DebugHeader);

--- a/Source/Tailwind.Traders.Web/ClientApp/src/shared/index.js
+++ b/Source/Tailwind.Traders.Web/ClientApp/src/shared/index.js
@@ -1,4 +1,5 @@
 import Header from './header/header';
+import DebugHeader from './debugHeader/debugHeader';
 import Footer from './footer/footer';
 import LoadingSpinner from './loadingSpinner/loadingSpinner'
 import UploadFile from './uploadFile/uploadFile'
@@ -6,6 +7,7 @@ import Card from './card/card'
 
 export {
     Header,
+    DebugHeader,
     Footer,
     LoadingSpinner,
     UploadFile,

--- a/Source/Tailwind.Traders.Web/Controllers/SettingsController.cs
+++ b/Source/Tailwind.Traders.Web/Controllers/SettingsController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Tailwind.Traders.Web.Controllers
 {
@@ -9,7 +10,20 @@ namespace Tailwind.Traders.Web.Controllers
     public class SettingsController : ControllerBase
     {
         private readonly Settings _settings;
-        public SettingsController(IOptionsSnapshot<Settings> settings) => _settings = settings.Value;
+        public SettingsController(IOptionsSnapshot<Settings> settings)
+        {
+            _settings = settings.Value;
+            if (!string.IsNullOrEmpty(_settings.SqlConnectionString))
+            {
+                var match = Regex.Match(_settings.SqlConnectionString, @"Server=(tcp:)?(?<servername>[^,;]+)");
+                _settings.DebugInformation.SqlServerName = match.Groups["servername"].Value;
+            }
+            if (!string.IsNullOrEmpty(_settings.MongoConnectionString))
+            {
+                var match = Regex.Match(_settings.MongoConnectionString, @"//([^:]+:[^:]+@)?(?<servername>[^:/]+)");
+                _settings.DebugInformation.MongoServerName = match.Groups["servername"].Value;
+            }
+        }
 
         [HttpGet()]
         public ActionResult<Settings> GetSettings()

--- a/Source/Tailwind.Traders.Web/Settings.cs
+++ b/Source/Tailwind.Traders.Web/Settings.cs
@@ -1,4 +1,4 @@
-using System;
+using Newtonsoft.Json;
 
 namespace Tailwind.Traders.Web
 {
@@ -12,11 +12,18 @@ namespace Tailwind.Traders.Web
         public string ApiUrl {get; set;}
         public string ApiUrlShoppingCart {get; set;}
         public bool UseB2C { get; set; }
+        [JsonIgnore]
+        public string SqlConnectionString { get; set; }
+        [JsonIgnore]
+        public string MongoConnectionString { get; set; }
 
         public B2CAuth B2CAuth { get; set; }
         public CartSettings Cart {get; set;}
         public ApplicationInsightsSettings ApplicationInsights { get; set; }
             = new ApplicationInsightsSettings();
+
+        public DebugInformationSettings DebugInformation { get; set; }
+            = new DebugInformationSettings();
 
         public bool ByPassShoppingCartApi {get; set;}
 
@@ -67,5 +74,13 @@ namespace Tailwind.Traders.Web
     public class ApplicationInsightsSettings
     {
         public string InstrumentationKey { get; set; } = "";
+    }
+
+    public class DebugInformationSettings
+    {
+        public string SqlServerName { get; set; }
+        public string MongoServerName { get; set; }
+        public string CustomText { get; set; }
+        public bool ShowDebug { get; set; }
     }
 }

--- a/Source/Tailwind.Traders.Web/appsettings.json
+++ b/Source/Tailwind.Traders.Web/appsettings.json
@@ -18,5 +18,9 @@
   },
   "ApiUrl": "http://localhost:5200/v1",
   "ApiUrlShoppingCart": "http://localhost:3000",
-  "UseB2C": false
+  "UseB2C": false,
+  "DebugInformation": {
+    "ShowDebug": false,
+    "CustomText": ""
+  }
 }


### PR DESCRIPTION
Display a banner on the top of the site with debug information.

Examples of how this will be used:
- Demo database migrations - display database server names
- Demo regional failover (e.g., Azure Front Door) - display the site's region name

To enable, set the `DebugInformation__ShowDebug` environment variable to `true`.

To set the custom text, use the `DebugInformation__CustomText` environment variable.

Screenshot of what the banner looks like:

![image](https://user-images.githubusercontent.com/3982077/63644067-0f433400-c695-11e9-8ec2-5ae43fc8da21.png)
