### PR TITLE
replace serverFarmId concat with resourceId

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -167,7 +167,7 @@
           ],
           "alwaysOn": "[variables('alwaysOn')]"
         },
-        "serverFarmId": "[concat('/subscriptions/', variables('subscriptionId'),'/resourcegroups/', variables('serverFarmResourceGroup'), '/providers/Microsoft.Web/serverfarms/', variables('hostingPlanName'))]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
         "hostingEnvironment": "[variables('hostingEnvironment')]",
         "clientAffinityEnabled": true
       },


### PR DESCRIPTION
Deployments have begun to fail based on an invalid `serverFarmId`.  Using the `resourceId` function seems to resolve that and generate the correct ID.

This is currently blocking AIML20 on the Ignite Tour and I fixed it in a template I derived from this base for AIML50 ( see https://github.com/microsoft/ignite-learning-paths-training-aiml/pull/76 )