### PR TITLE
fix: use resourceId function rather than concat for serverFarmId b/c deploy fails

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -167,7 +167,7 @@
           ],
           "alwaysOn": "[variables('alwaysOn')]"
         },
-        "serverFarmId": "[concat('/subscriptions/', variables('subscriptionId'),'/resourcegroups/', variables('serverFarmResourceGroup'), '/providers/Microsoft.Web/serverfarms/', variables('hostingPlanName'))]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms/', variables('hostingPlanName'))]",
         "hostingEnvironment": "[variables('hostingEnvironment')]",
         "clientAffinityEnabled": true
       },


### PR DESCRIPTION
When deploying the standalone template, it would fail due to validation errors not finding the serverFarmId. Changing the template to use the resourceId function rather than concat fixes the issue.