### PR TITLE
Add condition for deploying with source control integration

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -35,6 +35,10 @@
     "branch": {
       "type": "string",
       "defaultValue": "master"
+    },
+    "sourceControl": {
+      "type": "bool",
+      "defaultValue": true
     }
   },
   "variables": {
@@ -173,6 +177,7 @@
       },
       "resources": [
         {
+          "condition": "[parameters('sourceControl')]",
           "apiVersion": "2015-08-01",
           "name": "web",
           "type": "sourcecontrols",


### PR DESCRIPTION
Deploying from GitHub Actions is failing due to App Service source control integration. 

A condition is added to allow deployment without integration with GitHub.  The default value is true to maintain the same behavior if the parameter value is not specified.