### PR TITLE
Updated deployment api > apps/v1

### DIFF
--- a/Deploy/helm/web/templates/deployment.yaml
+++ b/Deploy/helm/web/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $name := include "tt-web.fullname" . -}}
 {{- $cfgname := printf "%s-%s" "cfg" $name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tt-web.fullname" . }}


### PR DESCRIPTION
Deployment apiVersion is no longer valid for recent cluster versions.